### PR TITLE
Refactor useAxiosFunction

### DIFF
--- a/src/components/DeleteThreadButton/DeleteThreadButton.tsx
+++ b/src/components/DeleteThreadButton/DeleteThreadButton.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import axios from 'axios';
 import useAxiosFunction from '../../hooks/useAxiosFunction';
 import './DeleteThreadButton.css';
 
@@ -13,7 +12,6 @@ const DeleteThreadButton: React.FC = () => {
 
   const handleDelete = () => {
     axiosFetch({
-      axiosInstance: axios,
       method: 'DELETE',
       url: `/api/v1/threads/${id}`,
     }).then(() => {

--- a/src/hooks/useAxiosFunction.ts
+++ b/src/hooks/useAxiosFunction.ts
@@ -1,14 +1,6 @@
-import { useEffect, useState, Dispatch, SetStateAction } from 'react';
-import { AxiosError, AxiosResponse } from 'axios';
-type setterFunctionArray = Dispatch<SetStateAction<any>>[];
-
-interface Config {
-  axiosInstance: any;
-  method: string;
-  url: string;
-  requestConfig?: Record<string, any>;
-  setterFunctions?: setterFunctionArray;
-}
+import { useEffect, useState } from 'react';
+import { AxiosError, AxiosResponse, AxiosRequestConfig } from 'axios';
+import axios from '../apis/reviveme';
 
 const useAxiosFunction = () => {
   const [response, setResponse] = useState<any[] | any>([]);
@@ -16,29 +8,23 @@ const useAxiosFunction = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [controller, setController] = useState<AbortController>();
 
-  const axiosFetch = async (config: Config) => {
-    const {
-      axiosInstance,
-      method,
-      url,
-      requestConfig = {},
-      setterFunctions = [],
-    } = config;
+  const axiosFetch = async (
+    config: AxiosRequestConfig,
+    setterFunctions: Array<(data: any) => void> = [],
+  ) => {
     setLoading(true);
     const ctrl = new AbortController();
     setController(ctrl);
 
-    await axiosInstance[method.toLowerCase()](url, {
-      ...requestConfig,
-      signal: ctrl.signal,
-    })
+    await axios
+      .request(config)
       .then((res: AxiosResponse) => {
         console.log('useAxiosFunction Response:', res);
         setResponse(res.data);
         setterFunctions?.forEach((func) => func(res.data));
       })
       .catch((err: AxiosError) => {
-        console.log('useAxiosFunction Error:', err.message);
+        console.log('useAxiosFunction Error:', err.message, err.response?.data);
         setError(err.message);
       })
       .finally(() => {

--- a/src/hooks/useAxiosFunction.ts
+++ b/src/hooks/useAxiosFunction.ts
@@ -1,8 +1,15 @@
 import { useEffect, useState } from 'react';
-import { AxiosError, AxiosResponse, AxiosRequestConfig } from 'axios';
-import axios from '../apis/reviveme';
+import {
+  AxiosError,
+  AxiosResponse,
+  AxiosRequestConfig,
+  AxiosInstance,
+} from 'axios';
+import defaultAxiosInstance from '../apis/reviveme';
 
-const useAxiosFunction = () => {
+const useAxiosFunction = (
+  axiosInstance: AxiosInstance = defaultAxiosInstance,
+) => {
   const [response, setResponse] = useState<any[] | any>([]);
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
@@ -16,7 +23,7 @@ const useAxiosFunction = () => {
     const ctrl = new AbortController();
     setController(ctrl);
 
-    await axios
+    await axiosInstance
       .request(config)
       .then((res: AxiosResponse) => {
         console.log('useAxiosFunction Response:', res);

--- a/src/views/Post/CreateThreadForm.tsx
+++ b/src/views/Post/CreateThreadForm.tsx
@@ -1,20 +1,19 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import React, { useState, ChangeEvent, FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
-import axios from '../../apis/reviveme';
 import useAxiosFunction from '../../hooks/useAxiosFunction';
 import './CreateThreadForm.css';
 
 interface PostData {
   title: string;
-  author: string;
+  author_id: number;
   content: string;
 }
 
 const CreateThreadForm: React.FC = () => {
   const [postData, setPostData] = useState<PostData>({
     title: '',
-    author: '',
+    author_id: 1, // TODO: we can remove this once we have auth
     content: '',
   });
 
@@ -32,16 +31,11 @@ const CreateThreadForm: React.FC = () => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     axiosFetch({
-      axiosInstance: axios,
       method: 'POST',
       url: '/api/v1/threads',
-      requestConfig: {
-        // TODO: change hardcoded values once we get user API running
-        data: {
-          title: postData.title,
-          content: postData.content,
-          author_id: 1,
-        },
+      data: {
+        ...postData,
+        author_id: 1, // TODO remove this once we have auth
       },
     }).then(() => {
       navigate('/');

--- a/src/views/ThreadPage/EditThreadForm.tsx
+++ b/src/views/ThreadPage/EditThreadForm.tsx
@@ -1,6 +1,5 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import React, { ChangeEvent, FormEvent } from 'react';
-import axios from '../../apis/reviveme';
 import useAxiosFunction from '../../hooks/useAxiosFunction';
 import Thread from '../../types/CommonTypes';
 
@@ -28,14 +27,11 @@ const EditThreadForm: React.FC<EditThreadFormProps> = ({
   const handleEditSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     axiosFetch({
-      axiosInstance: axios,
       method: 'PUT',
       url: `/api/v1/threads/${thread.id}`,
-      requestConfig: {
-        // TODO: change hardcoded values once we get user API running
-        data: {
-          content: tempThread.content,
-        },
+      // TODO: change hardcoded values once we get user API running
+      data: {
+        content: tempThread.content,
       },
     }).then(() => {
       setIsEditing(false);

--- a/src/views/ThreadPage/index.tsx
+++ b/src/views/ThreadPage/index.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import Thread from '../../types/CommonTypes';
-import axios from '../../apis/reviveme';
 import DeleteThreadButton from '../../components/DeleteThreadButton/DeleteThreadButton';
 import useAxiosFunction from '../../hooks/useAxiosFunction';
 import EditThreadForm from './EditThreadForm';
@@ -14,12 +13,13 @@ const ThreadPage: React.FC = () => {
   const [thread, error, loading, axiosFetch] = useAxiosFunction();
 
   useEffect(() => {
-    axiosFetch({
-      axiosInstance: axios,
-      method: 'GET',
-      url: `/api/v1/threads/${id}`,
-      setterFunctions: [setTempThread],
-    });
+    axiosFetch(
+      {
+        method: 'GET',
+        url: `/api/v1/threads/${id}`,
+      },
+      [setTempThread],
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2140,16 +2140,9 @@
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@^18.0.0":
+"@types/react-dom@^18.0.0", "@types/react-dom@^18.2.17":
   version "18.2.17"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz"
-  integrity sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@^18.2.17":
-  version "18.2.17"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.17.tgz#375c55fab4ae671bd98448dcfa153268d01d6f64"
   integrity sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==
   dependencies:
     "@types/react" "*"


### PR DESCRIPTION
- Now you don't have to pass in the axios instance in every request
  - You can specify it upon calling `useAxiosFunction`, but it will use the one axios instance we have defined by default.
- The `axiosFetch` function now internally uses the `axios.request` method
  - Before, we were calling the http method-specific functions (i.e. `axios.get`, `axios.post`, etc). This caused a little bit of a problem, as some of them have different function signatures, so we would have had to change the parameters we pass in depending on the function we were calling: <img width="740" alt="image" src="https://github.com/Seanlebon/reviveme-fe/assets/28808693/8de758ad-760a-42f3-b8de-43ddeef127f8">
- We now no longer wrap the data passed in `post` request body in a `data` object, nor do we send a `signal` object in those same requests.