### PR TITLE
Properly indicate that a thread has been deleted

### DIFF
--- a/src/views/ThreadPage/index.tsx
+++ b/src/views/ThreadPage/index.tsx
@@ -35,7 +35,7 @@ const ThreadPage: React.FC = () => {
       )}
       {!loading && !error && thread && (
         <div className='container'>
-          <h2>{thread.title}</h2>
+          <h2>{thread.deleted ? '[deleted]' : thread.title}</h2>
           {isEditing ? (
             <EditThreadForm
               setIsEditing={setIsEditing}
@@ -44,21 +44,25 @@ const ThreadPage: React.FC = () => {
               thread={thread}
             />
           ) : (
-            <p>{tempThread.content}</p>
+            <p>{thread.deleted ? '[deleted]' : tempThread.content}</p>
           )}
-          <div className='row'>
-            <div className='col'>
-              <DeleteThreadButton />
+
+          {!thread.deleted && (
+            <div className='row'>
+              <div className='col'>
+                <DeleteThreadButton />
+              </div>
+              <div className='col'>
+                <button
+                  className='btn btn-primary btn-sm'
+                  onClick={setIsEditingTrue}
+                >
+                  Edit
+                </button>
+              </div>
             </div>
-            <div className='col'>
-              <button
-                className='btn btn-primary btn-sm'
-                onClick={setIsEditingTrue}
-              >
-                Edit
-              </button>
-            </div>
-          </div>
+          )}
+
           <Link to='/'>Go to Home Page</Link>
         </div>
       )}


### PR DESCRIPTION
If a thread is deleted and a user enters the URL that takes them to that thread, they should see [deleted] instead of a blank page with edit and delete buttons (which is what they see currently).

The rationale for this is to allow users to link to threads that have been deleted and still see the comments on them (also this is what Reddit does LOL).

Old:
<img width="957" alt="image" src="https://github.com/Seanlebon/reviveme-fe/assets/28808693/a767f8c6-71b4-4f22-8abb-83e887d2aa73">

New:
<img width="953" alt="image" src="https://github.com/Seanlebon/reviveme-fe/assets/28808693/9ada5048-8ab8-49d4-96a1-b02e00a0072e">
