### PR TITLE
Add created at date/time to threads and comments

### DIFF
--- a/src/components/ThreadCard/ThreadCard.css
+++ b/src/components/ThreadCard/ThreadCard.css
@@ -18,6 +18,12 @@
   color: #888;
 }
 
+.threadcard-date {
+  font-size: 0.8rem;
+  color: #888;
+  font-style: italic;
+}
+
 /* MyCardComponent.css */
 
 .card-container {

--- a/src/components/ThreadCard/ThreadCard.tsx
+++ b/src/components/ThreadCard/ThreadCard.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import './ThreadCard.css';
 import { Thread } from '../../types/CommonTypes';
 import VoteView from '../VoteView/VoteView';
+import { getCreatedAtDate, getCreatedAtTime } from '../../utils/DateTimeUtils';
 
 interface ThreadCardProps {
   thread: Thread;
@@ -14,13 +15,6 @@ const ThreadCard: React.FC<ThreadCardProps> = ({ thread }) => {
   const { id, author_name, title } = thread;
   const handleClick = () => {
     navigate(`/threads/${id}`);
-  };
-
-  const getCreatedAtDate = () =>
-    thread.created_at.substring(0, 'YYYY-MM-DD'.length);
-  const getCreatedAtTime = () => {
-    const startIndex = 'YYYY-MM-DDT'.length;
-    return thread.created_at.substring(startIndex, startIndex + 'HH:MM'.length);
   };
 
   return (
@@ -39,8 +33,8 @@ const ThreadCard: React.FC<ThreadCardProps> = ({ thread }) => {
             <p className='threadcard-author my-0'> Posted by: {author_name}</p>
             <h5 className='card-title'>{title}</h5>
           </div>
-          <p className='threadcard-author'>
-            {getCreatedAtDate() + ' ' + getCreatedAtTime()}
+          <p className='threadcard-date'>
+            {getCreatedAtDate(thread) + ' ' + getCreatedAtTime(thread)}
           </p>
           {/* On click, this should bring us to the corresponding thread page with comments */}
         </div>

--- a/src/components/ThreadCard/ThreadCard.tsx
+++ b/src/components/ThreadCard/ThreadCard.tsx
@@ -16,12 +16,32 @@ const ThreadCard: React.FC<ThreadCardProps> = ({ thread }) => {
     navigate(`/threads/${id}`);
   };
 
+  const getCreatedAtDate = () =>
+    thread.created_at.substring(0, 'YYYY-MM-DD'.length);
+  const getCreatedAtTime = () => {
+    const startIndex = 'YYYY-MM-DDT'.length;
+    return thread.created_at.substring(startIndex, startIndex + 'HH:MM'.length);
+  };
+
   return (
     <div className='card-container'>
       <div className='card'>
-        <div className='card-body my-0' onClick={handleClick}>
-          <p className='threadcard-author my-0'> Posted by: {author_name}</p>
-          <h5 className='card-title'>{title}</h5>
+        <div
+          className='card-body my-0'
+          onClick={handleClick}
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+          }}
+        >
+          <div>
+            <p className='threadcard-author my-0'> Posted by: {author_name}</p>
+            <h5 className='card-title'>{title}</h5>
+          </div>
+          <p className='threadcard-author'>
+            {getCreatedAtDate() + ' ' + getCreatedAtTime()}
+          </p>
           {/* On click, this should bring us to the corresponding thread page with comments */}
         </div>
         <div

--- a/src/components/VoteView/VoteView.css
+++ b/src/components/VoteView/VoteView.css
@@ -1,6 +1,5 @@
 .vote-button {
   margin-left: 1%;
-  margin-right: 1%;
   border: transparent;
   fill: none;
   background-color: transparent;

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -21,6 +21,7 @@ interface Comment {
   score: number;
   upvoted: boolean;
   downvoted: boolean;
+  created_at: string;
   children: Comment[];
 }
 

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -8,6 +8,7 @@ interface Thread {
   score: number;
   upvoted: boolean;
   downvoted: boolean;
+  created_at: string;
 }
 
 interface Comment {

--- a/src/utils/DateTimeUtils.ts
+++ b/src/utils/DateTimeUtils.ts
@@ -1,13 +1,18 @@
 import { Thread, Comment } from '../types/CommonTypes';
 
+// Gets a user's local timezone
+const getTimeZone = () => Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 // Separate ISO timestamp into date and time
 const getCreatedAtDate = (item: Thread | Comment) =>
-  item.created_at.substring(0, 'YYYY-MM-DD'.length);
+  new Date(item.created_at).toLocaleDateString('EN-CA', {
+    timeZone: getTimeZone(),
+  });
 
-const getCreatedAtTime = (item: Thread | Comment) => {
-  const startIndex = 'YYYY-MM-DDT'.length;
-  return item.created_at.substring(startIndex, startIndex + 'HH:MM'.length);
-};
+const getCreatedAtTime = (item: Thread | Comment) =>
+  new Date(item.created_at).toLocaleTimeString('EN-CA', {
+    timeZone: getTimeZone(),
+  });
 
 const pluralize = (count: number, unit: string) =>
   Math.floor(count) == 1 ? unit : unit + 's';

--- a/src/utils/DateTimeUtils.ts
+++ b/src/utils/DateTimeUtils.ts
@@ -1,0 +1,40 @@
+import { Thread, Comment } from '../types/CommonTypes';
+
+// Separate ISO timestamp into date and time
+const getCreatedAtDate = (item: Thread | Comment) =>
+  item.created_at.substring(0, 'YYYY-MM-DD'.length);
+
+const getCreatedAtTime = (item: Thread | Comment) => {
+  const startIndex = 'YYYY-MM-DDT'.length;
+  return item.created_at.substring(startIndex, startIndex + 'HH:MM'.length);
+};
+
+const pluralize = (count: number, unit: string) =>
+  Math.floor(count) == 1 ? unit : unit + 's';
+
+// Get the approximate time it's been since the created_at date
+const getTimeSinceCreated = (item: Thread | Comment) => {
+  const timestamp = Date.parse(item.created_at);
+  const seconds = (Date.now() - timestamp) / 1000;
+
+  if (seconds < 60)
+    return `${Math.floor(seconds)} ${pluralize(seconds, 'second')}`;
+
+  const minutes = seconds / 60;
+  if (minutes < 60)
+    return `${Math.floor(minutes)} ${pluralize(minutes, 'minute')}`;
+
+  const hours = minutes / 60;
+  if (hours < 24) return `${Math.floor(hours)} ${pluralize(hours, 'hour')}`;
+
+  const days = hours / 24;
+  if (days < 30) return `${Math.floor(days)} ${pluralize(days, 'day')}`;
+
+  const months = days / 30;
+  if (days < 365) return `${months} ${pluralize(months, 'month')}`;
+
+  const years = days / 365;
+  return `${years} ${pluralize(years, 'year')}`;
+};
+
+export { getCreatedAtDate, getCreatedAtTime, getTimeSinceCreated };

--- a/src/views/ThreadPage/Comment/Comment.css
+++ b/src/views/ThreadPage/Comment/Comment.css
@@ -2,6 +2,7 @@
   margin: 5px;
   padding: 5px;
   padding-left: 10px;
+  padding-right: 10px;
   border: 1px solid #ccc;
   border-radius: 5px;
   background-color: #fff;
@@ -14,6 +15,12 @@
   color: #888;
   margin-top: 0em;
   margin-bottom: 0.2em;
+}
+
+.comment-date {
+  font-size: 0.8rem;
+  color: #888;
+  font-style: italic;
 }
 
 .comment-footer {

--- a/src/views/ThreadPage/Comment/Comment.tsx
+++ b/src/views/ThreadPage/Comment/Comment.tsx
@@ -6,6 +6,10 @@ import { AxiosError } from 'axios';
 import CommentReplyForm from './CommentReplyForm';
 import EditCommentForm from './EditCommentForm';
 import VoteView from '../../../components/VoteView/VoteView';
+import {
+  getCreatedAtDate,
+  getCreatedAtTime,
+} from '../../../utils/DateTimeUtils';
 
 interface CommentProps {
   comment: CommentType;
@@ -35,9 +39,14 @@ const Comment: React.FC<CommentProps> = ({ comment, refetchComments }) => {
 
   return (
     <div className='comment-card'>
-      <p className='author-username'>
-        {comment.deleted ? '[deleted]' : comment.author_username}
-      </p>
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <p className='author-username'>
+          {comment.deleted ? '[deleted]' : comment.author_username}
+        </p>
+        <p className='comment-date'>
+          {getCreatedAtDate(comment) + ' ' + getCreatedAtTime(comment)}
+        </p>
+      </div>
       {showEditForm ? (
         <EditCommentForm
           comment={comment}

--- a/src/views/ThreadPage/index.css
+++ b/src/views/ThreadPage/index.css
@@ -1,0 +1,5 @@
+.thread-date {
+  font-size: 0.8rem;
+  color: #888;
+  font-style: italic;
+}

--- a/src/views/ThreadPage/index.tsx
+++ b/src/views/ThreadPage/index.tsx
@@ -9,6 +9,11 @@ import CreateCommentForm from './Comment/CreateCommentForm';
 import useAxios from '../../hooks/useAxios';
 import axios from '../../apis/reviveme';
 import VoteView from '../../components/VoteView/VoteView';
+import {
+  getCreatedAtDate,
+  getCreatedAtTime,
+  getTimeSinceCreated,
+} from '../../utils/DateTimeUtils';
 
 const ThreadPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -50,6 +55,11 @@ const ThreadPage: React.FC = () => {
       {!loading && !error && thread && (
         <div className='container'>
           <h2>{thread.deleted ? '[deleted]' : thread.title}</h2>
+          <p className='thread-date'>
+            Posted on{' '}
+            {getCreatedAtDate(thread) + ' ' + getCreatedAtTime(thread)}
+            {' (' + getTimeSinceCreated(thread) + ' ago)'}
+          </p>
 
           {isEditing ? (
             <EditThreadForm


### PR DESCRIPTION
Sister PR: https://github.com/Seanlebon/reviveme-be/pull/25

This adds date and time of creation to thread cards, the thread page, and comment cards. Additionally, this adds a file with common date/time utils. Still a little rough-looking but in my opinion, we can fix that after UI is finalized.

For the future:
- We can just show the "x hours ago" message instead of the full date/time in our threads + comments. Then we could make the actual date and time (e.g. `2024-01-05 15:48`) show up as a tooltip when you hover over it.

![image](https://github.com/Seanlebon/reviveme-fe/assets/28808693/6f1fbc0a-2d58-4b3f-8761-4b71a480702e)

![image](https://github.com/Seanlebon/reviveme-fe/assets/28808693/c3e675c6-8036-4b9d-94fb-ce33b7ee0b15)
