### PR TITLE
Add thread sorting dropdown to thread list and thread page

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.6.2",
     "bootstrap": "^5.3.2",
     "react": "^18.2.0",
+    "react-bootstrap": "^2.10.2",
     "react-bootstrap-icons": "^1.10.3",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.0",

--- a/src/components/SortDropdown/SortDropdown.css
+++ b/src/components/SortDropdown/SortDropdown.css
@@ -1,0 +1,14 @@
+.sortDropdownContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.sortText {
+  margin: 0;
+}
+
+.dropdownToggle {
+  border: none;
+  width: 6em; /* This is so the 'sort by' text doesn't move when the sort type changes */
+}

--- a/src/components/SortDropdown/SortDropdown.tsx
+++ b/src/components/SortDropdown/SortDropdown.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Dropdown } from 'react-bootstrap';
+import sortTypes from '../../constants/SortTypes';
+
+interface SortDropdownProps {
+  sort: string | null;
+  setSort: (sort: string | null) => void;
+}
+
+const SortDropdown: React.FC<SortDropdownProps> = ({ sort, setSort }) => {
+  return (
+    <>
+      <p style={{ margin: 0 }}>Sort by: </p>
+      <Dropdown
+        data-bs-theme='dark'
+        onSelect={(eventKey: string | null, event: Object) => {
+          setSort(eventKey);
+        }}
+      >
+        <Dropdown.Toggle
+          id='dropdown-button-dark-sort-menu'
+          variant='secondary'
+          style={{
+            backgroundColor: 'transparent',
+            color: 'black',
+            border: 'none',
+            width: '6em', // This is to make it so the 'sort by' text doesn't move when the sort changes
+          }}
+        >
+          {sort}
+        </Dropdown.Toggle>
+
+        <Dropdown.Menu>
+          {Object.values(sortTypes).map((sortType) => (
+            <Dropdown.Item
+              key={sortType}
+              href={`#/action-${sortType}`}
+              active={sort === sortType}
+              eventKey={sortType}
+            >
+              {
+                sortType.charAt(0).toUpperCase() +
+                  sortType.slice(1) /* Capitalize first letter */
+              }
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+      </Dropdown>
+    </>
+  );
+};
+
+export default SortDropdown;

--- a/src/components/SortDropdown/SortDropdown.tsx
+++ b/src/components/SortDropdown/SortDropdown.tsx
@@ -6,17 +6,20 @@ import './SortDropdown.css';
 
 interface SortDropdownProps {
   sort: string | null;
-  setSort: (sort: string | null) => void;
+  onSortChange: (sort: string | null) => void;
 }
 
-const SortDropdown: React.FC<SortDropdownProps> = ({ sort, setSort }) => {
+const SortDropdown: React.FC<SortDropdownProps> = ({
+  sort,
+  onSortChange = (_) => {},
+}) => {
   return (
     <div className='sortDropdownContainer'>
       <p className='sortText'>Sort by: </p>
       <Dropdown
         data-bs-theme='dark'
         onSelect={(eventKey: string | null, event: Object) => {
-          setSort(eventKey);
+          onSortChange(eventKey);
         }}
       >
         <Dropdown.Toggle

--- a/src/components/SortDropdown/SortDropdown.tsx
+++ b/src/components/SortDropdown/SortDropdown.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Dropdown } from 'react-bootstrap';
 import sortTypes from '../../constants/SortTypes';
 
+import './SortDropdown.css';
+
 interface SortDropdownProps {
   sort: string | null;
   setSort: (sort: string | null) => void;
@@ -9,8 +11,8 @@ interface SortDropdownProps {
 
 const SortDropdown: React.FC<SortDropdownProps> = ({ sort, setSort }) => {
   return (
-    <>
-      <p style={{ margin: 0 }}>Sort by: </p>
+    <div className='sortDropdownContainer'>
+      <p className='sortText'>Sort by: </p>
       <Dropdown
         data-bs-theme='dark'
         onSelect={(eventKey: string | null, event: Object) => {
@@ -20,12 +22,8 @@ const SortDropdown: React.FC<SortDropdownProps> = ({ sort, setSort }) => {
         <Dropdown.Toggle
           id='dropdown-button-dark-sort-menu'
           variant='secondary'
-          style={{
-            backgroundColor: 'transparent',
-            color: 'black',
-            border: 'none',
-            width: '6em', // This is to make it so the 'sort by' text doesn't move when the sort changes
-          }}
+          className='dropdownToggle'
+          style={{ backgroundColor: 'transparent', color: 'black' }}
         >
           {sort}
         </Dropdown.Toggle>
@@ -45,7 +43,7 @@ const SortDropdown: React.FC<SortDropdownProps> = ({ sort, setSort }) => {
           ))}
         </Dropdown.Menu>
       </Dropdown>
-    </>
+    </div>
   );
 };
 

--- a/src/components/SortDropdown/SortDropdown.tsx
+++ b/src/components/SortDropdown/SortDropdown.tsx
@@ -34,7 +34,6 @@ const SortDropdown: React.FC<SortDropdownProps> = ({ sort, setSort }) => {
           {Object.values(sortTypes).map((sortType) => (
             <Dropdown.Item
               key={sortType}
-              href={`#/action-${sortType}`}
               active={sort === sortType}
               eventKey={sortType}
             >

--- a/src/constants/SortTypes.ts
+++ b/src/constants/SortTypes.ts
@@ -1,0 +1,6 @@
+const sortTypes = Object.freeze({
+  newest: 'newest',
+  top: 'top',
+});
+
+export default sortTypes;

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { AxiosError, AxiosResponse } from 'axios';
+import { AxiosError, AxiosResponse, AxiosRequestConfig } from 'axios';
 interface Config {
   axiosInstance: any; // Replace 'any' with the actual type of your Axios instance
   method: string;
@@ -8,13 +8,22 @@ interface Config {
 }
 
 const useAxios = (config: Config) => {
-  const { axiosInstance, method, url, requestConfig = {} } = config;
+  const { axiosInstance, method, url } = config;
   const [response, setResponse] = useState<any[] | any>([]); // Replace 'any[]' with the actual type of your response data
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
   const [reload, setReload] = useState<number>(0);
 
-  const refetch = () => setReload((prev) => prev + 1);
+  const [requestConfig, setRequestConfig] = useState<AxiosRequestConfig>(
+    config.requestConfig || ({} as AxiosRequestConfig),
+  );
+
+  const refetch = (newReqConfigParams: Object = {}) => {
+    setRequestConfig({ ...requestConfig, ...newReqConfigParams });
+    setLoading(true);
+
+    setReload((prev) => prev + 1);
+  };
 
   useEffect(() => {
     const controller = new AbortController();

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -6,6 +6,7 @@ import { Thread } from '../../types/CommonTypes';
 import ThreadCard from '../../components/ThreadCard/ThreadCard';
 import useAxios from '../../hooks/useAxios';
 import SortDropdown from '../../components/SortDropdown/SortDropdown';
+import sortTypes from '../../constants/SortTypes';
 
 const Home: React.FC = () => {
   const [threads, error, loading, refetch] = useAxios({
@@ -14,7 +15,7 @@ const Home: React.FC = () => {
     url: '/api/v1/threads',
   });
 
-  const [sort, setSort] = React.useState<string | null>('newest');
+  const [sort, setSort] = React.useState<string | null>(sortTypes.newest);
 
   return (
     <div>

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -5,6 +5,7 @@ import axios from '../../apis/reviveme';
 import { Thread } from '../../types/CommonTypes';
 import ThreadCard from '../../components/ThreadCard/ThreadCard';
 import useAxios from '../../hooks/useAxios';
+import { Dropdown } from 'react-bootstrap';
 
 const Home: React.FC = () => {
   const [threads, error, loading] = useAxios({
@@ -12,6 +13,8 @@ const Home: React.FC = () => {
     method: 'GET',
     url: '/api/v1/threads',
   });
+
+  const [sort, setSort] = React.useState<string | null>('newest');
 
   return (
     <div>
@@ -22,6 +25,57 @@ const Home: React.FC = () => {
       {!loading && !error && threads && (
         <div className='container'>
           <h2>Home Page</h2>
+
+          <div
+            className='card'
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: 'flex-end',
+              alignItems: 'center',
+              alignContent: 'center',
+              border: 'none',
+              cursor: 'default',
+            }}
+          >
+            <p style={{ margin: 0 }}>Sort by: </p>
+            <Dropdown
+              data-bs-theme='dark'
+              onSelect={(eventKey: string | null, event: Object) => {
+                setSort(eventKey);
+              }}
+            >
+              <Dropdown.Toggle
+                id='dropdown-button-dark-sort-menu'
+                variant='secondary'
+                style={{
+                  backgroundColor: 'transparent',
+                  color: 'black',
+                  border: 'none',
+                  width: '6em', // This is to make it so the 'sort by' text doesn't move when the sort changes
+                }}
+              >
+                {sort}
+              </Dropdown.Toggle>
+
+              <Dropdown.Menu>
+                <Dropdown.Item
+                  href='#/action-1'
+                  active={sort === 'newest'}
+                  eventKey={'newest'}
+                >
+                  Newest
+                </Dropdown.Item>
+                <Dropdown.Item
+                  href='#/action-2'
+                  active={sort === 'top'}
+                  eventKey={'top'}
+                >
+                  Top
+                </Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
+          </div>
           {threads.map((thread: Thread) => (
             <div key={thread.id}>
               <ThreadCard thread={thread} />

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -6,6 +6,7 @@ import { Thread } from '../../types/CommonTypes';
 import ThreadCard from '../../components/ThreadCard/ThreadCard';
 import useAxios from '../../hooks/useAxios';
 import { Dropdown } from 'react-bootstrap';
+import SortDropdown from '../../components/SortDropdown/SortDropdown';
 
 const Home: React.FC = () => {
   const [threads, error, loading] = useAxios({
@@ -38,43 +39,7 @@ const Home: React.FC = () => {
               cursor: 'default',
             }}
           >
-            <p style={{ margin: 0 }}>Sort by: </p>
-            <Dropdown
-              data-bs-theme='dark'
-              onSelect={(eventKey: string | null, event: Object) => {
-                setSort(eventKey);
-              }}
-            >
-              <Dropdown.Toggle
-                id='dropdown-button-dark-sort-menu'
-                variant='secondary'
-                style={{
-                  backgroundColor: 'transparent',
-                  color: 'black',
-                  border: 'none',
-                  width: '6em', // This is to make it so the 'sort by' text doesn't move when the sort changes
-                }}
-              >
-                {sort}
-              </Dropdown.Toggle>
-
-              <Dropdown.Menu>
-                <Dropdown.Item
-                  href='#/action-1'
-                  active={sort === 'newest'}
-                  eventKey={'newest'}
-                >
-                  Newest
-                </Dropdown.Item>
-                <Dropdown.Item
-                  href='#/action-2'
-                  active={sort === 'top'}
-                  eventKey={'top'}
-                >
-                  Top
-                </Dropdown.Item>
-              </Dropdown.Menu>
-            </Dropdown>
+            <SortDropdown sort={sort} setSort={setSort} />
           </div>
           {threads.map((thread: Thread) => (
             <div key={thread.id}>

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -5,11 +5,10 @@ import axios from '../../apis/reviveme';
 import { Thread } from '../../types/CommonTypes';
 import ThreadCard from '../../components/ThreadCard/ThreadCard';
 import useAxios from '../../hooks/useAxios';
-import { Dropdown } from 'react-bootstrap';
 import SortDropdown from '../../components/SortDropdown/SortDropdown';
 
 const Home: React.FC = () => {
-  const [threads, error, loading] = useAxios({
+  const [threads, error, loading, refetch] = useAxios({
     axiosInstance: axios,
     method: 'GET',
     url: '/api/v1/threads',
@@ -39,7 +38,13 @@ const Home: React.FC = () => {
               cursor: 'default',
             }}
           >
-            <SortDropdown sort={sort} setSort={setSort} />
+            <SortDropdown
+              sort={sort}
+              onSortChange={(newSort) => {
+                setSort(newSort);
+                refetch({ params: { sortby: newSort } });
+              }}
+            />
           </div>
           {threads.map((thread: Thread) => (
             <div key={thread.id}>

--- a/src/views/ThreadPage/Comment/Comment.css
+++ b/src/views/ThreadPage/Comment/Comment.css
@@ -9,6 +9,16 @@
   text-align: left;
 }
 
+.sort-dropdown-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  border: none;
+  box-shadow: none;
+  margin-top: 1em;
+}
+
 .author-username {
   font-size: 0.8rem;
   color: #888;

--- a/src/views/ThreadPage/Comment/Comment.css
+++ b/src/views/ThreadPage/Comment/Comment.css
@@ -13,7 +13,6 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  align-items: center;
   border: none;
   box-shadow: none;
   margin-top: 1em;

--- a/src/views/ThreadPage/Comment/CommentReplyForm.tsx
+++ b/src/views/ThreadPage/Comment/CommentReplyForm.tsx
@@ -27,6 +27,7 @@ const CommentReplyForm: React.FC<CommentReplyFormProps> = ({
   };
 
   const handleReplySubmit = () => {
+    console.log('Replying to comment', parentComment.id);
     axios
       .post(`/api/v1/threads/${id}/comments`, {
         author_id: 1, // TODO: change hardcoded value once we get user API running

--- a/src/views/ThreadPage/index.tsx
+++ b/src/views/ThreadPage/index.tsx
@@ -10,6 +10,7 @@ import useAxios from '../../hooks/useAxios';
 import axios from '../../apis/reviveme';
 import VoteView from '../../components/VoteView/VoteView';
 import SortDropdown from '../../components/SortDropdown/SortDropdown';
+import sortTypes from '../../constants/SortTypes';
 
 const ThreadPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -17,7 +18,7 @@ const ThreadPage: React.FC = () => {
   const [tempContent, setTempContent] = useState<string>('');
   const [thread, error, loading, axiosFetch] = useAxiosFunction();
 
-  const [sort, setSort] = useState<string | null>('newest');
+  const [sort, setSort] = useState<string | null>(sortTypes.newest);
 
   const [comments, commentError, commentLoading, refetchComments] = useAxios({
     axiosInstance: axios,

--- a/src/views/ThreadPage/index.tsx
+++ b/src/views/ThreadPage/index.tsx
@@ -96,7 +96,13 @@ const ThreadPage: React.FC = () => {
           <CreateCommentForm refetchComments={refetchComments} />
 
           <div className='sort-dropdown-container comment-card'>
-            <SortDropdown sort={sort} setSort={setSort} />
+            <SortDropdown
+              sort={sort}
+              onSortChange={(newSort) => {
+                setSort(newSort);
+                refetchComments({ params: { sortby: newSort } });
+              }}
+            />
           </div>
 
           {commentLoading && <p>Loading Comments...</p>}

--- a/src/views/ThreadPage/index.tsx
+++ b/src/views/ThreadPage/index.tsx
@@ -9,12 +9,15 @@ import CreateCommentForm from './Comment/CreateCommentForm';
 import useAxios from '../../hooks/useAxios';
 import axios from '../../apis/reviveme';
 import VoteView from '../../components/VoteView/VoteView';
+import SortDropdown from '../../components/SortDropdown/SortDropdown';
 
 const ThreadPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const [isEditing, setIsEditing] = useState(false);
   const [tempContent, setTempContent] = useState<string>('');
   const [thread, error, loading, axiosFetch] = useAxiosFunction();
+
+  const [sort, setSort] = useState<string | null>('newest');
 
   const [comments, commentError, commentLoading, refetchComments] = useAxios({
     axiosInstance: axios,
@@ -91,6 +94,11 @@ const ThreadPage: React.FC = () => {
           <hr style={{ paddingBottom: '2%' }} />
           <p style={{ textAlign: 'left' }}>Comments:</p>
           <CreateCommentForm refetchComments={refetchComments} />
+
+          <div className='sort-dropdown-container comment-card'>
+            <SortDropdown sort={sort} setSort={setSort} />
+          </div>
+
           {commentLoading && <p>Loading Comments...</p>}
           {!commentLoading && commentError && (
             <p>There was an error loading comments: {commentError}</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,6 +1121,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.21.0", "@babel/runtime@^7.22.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.7":
+  version "7.24.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.4.tgz#de795accd698007a66ba44add6cc86542aff1edd"
+  integrity sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15", "@babel/template@^7.3.3":
   version "7.22.15"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz"
@@ -1662,10 +1669,44 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@popperjs/core@^2.11.6":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
+"@react-aria/ssr@^3.5.0":
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.9.2.tgz#01b756965cd6e32b95217f968f513eb3bd6ee44b"
+  integrity sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
 "@remix-run/router@1.13.0":
   version "1.13.0"
   resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.13.0.tgz"
   integrity sha512-5dMOnVnefRsl4uRnAdoWjtVTdh8e6aZqgM4puy9nmEADH72ck+uXwzpJLEKE9Q6F8ZljNewLgmTfkxUrBdv4WA==
+
+"@restart/hooks@^0.4.9":
+  version "0.4.16"
+  resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.4.16.tgz#95ae8ac1cc7e2bd4fed5e39800ff85604c6d59fb"
+  integrity sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==
+  dependencies:
+    dequal "^2.0.3"
+
+"@restart/ui@^1.6.8":
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/@restart/ui/-/ui-1.6.8.tgz#61b73503d4690e2f0f58992d4d6ae1e89c276791"
+  integrity sha512-6ndCv3oZ7r9vuP1Ok9KH55TM1/UkdBnP/fSraW0DFDMbPMzWKhVKeFAIEUCRCSdzayjZDcFYK6xbMlipN9dmMA==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
+    "@popperjs/core" "^2.11.6"
+    "@react-aria/ssr" "^3.5.0"
+    "@restart/hooks" "^0.4.9"
+    "@types/warning" "^3.0.0"
+    dequal "^2.0.3"
+    dom-helpers "^5.2.0"
+    uncontrollable "^8.0.1"
+    warning "^4.0.3"
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
@@ -1845,6 +1886,13 @@
     "@svgr/plugin-jsx" "^5.5.0"
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
+
+"@swc/helpers@^0.5.0":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.8.tgz#65d56b1961487fd99795ffd8c68edb7a591571fb"
+  integrity sha512-lruDGw3pnfM3wmZHeW7JuhkGQaJjPyiKjxeGhdmfoOT53Ic9qb5JLDNaK2HUdl1zLDeX28H221UvKjfdvSLVMg==
+  dependencies:
+    tslib "^2.4.0"
 
 "@testing-library/dom@^8.5.0":
   version "8.20.1"
@@ -2147,6 +2195,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-transition-group@^4.4.6":
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.10.tgz#6ee71127bdab1f18f11ad8fb3322c6da27c327ac"
+  integrity sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "18.2.38"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.2.38.tgz"
@@ -2156,13 +2211,12 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@^18.2.45":
-  version "18.2.45"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.45.tgz#253f4fac288e7e751ab3dc542000fb687422c15c"
-  integrity sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==
+"@types/react@>=16.9.11", "@types/react@^18.2.45":
+  version "18.2.77"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.77.tgz#af2f857b6a6dfb6ca89ec102ebc147b1f1616880"
+  integrity sha512-CUT9KUUF+HytDM7WiXKLF9qUSg4tGImwy4FXTlfEDPEkkNUzJ7rVFolYweJ9fS1ljoIaP7M7Rdjc5eUm/Yu5AA==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/resolve@1.17.1":
@@ -2234,6 +2288,11 @@
   version "2.0.7"
   resolved "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
+"@types/warning@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.3.tgz#d1884c8cc4a426d1ac117ca2611bf333834c6798"
+  integrity sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==
 
 "@types/ws@^8.5.5":
   version "8.5.10"
@@ -3249,6 +3308,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz"
   integrity sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==
 
+classnames@^2.3.2:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 clean-css@^5.2.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz"
@@ -3896,6 +3960,14 @@ dom-converter@^0.2.0:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^5.0.1, dom-helpers@^5.2.0, dom-helpers@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -5291,6 +5363,13 @@ internal-slot@^1.0.4, internal-slot@^1.0.5:
     hasown "^2.0.0"
     side-channel "^1.0.4"
 
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
@@ -6451,7 +6530,7 @@ lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7709,7 +7788,15 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types-extra@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.1.1.tgz#58c3b74cbfbb95d304625975aa2f0848329a010b"
+  integrity sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==
+  dependencies:
+    react-is "^16.3.2"
+    warning "^4.0.0"
+
+prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7804,6 +7891,31 @@ react-app-polyfill@^3.0.0:
     regenerator-runtime "^0.13.9"
     whatwg-fetch "^3.6.2"
 
+react-bootstrap-icons@^1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/react-bootstrap-icons/-/react-bootstrap-icons-1.10.3.tgz#5d64a93c7b172856b03c7d3cd5119a025b094966"
+  integrity sha512-j4hSby6gT9/enhl3ybB1tfr1slZNAYXDVntcRrmVjxB3//2WwqrzpESVqKhyayYVaWpEtnwf9wgUQ03cuziwrw==
+  dependencies:
+    prop-types "^15.7.2"
+
+react-bootstrap@^2.10.2:
+  version "2.10.2"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-2.10.2.tgz#3b609eb0170e31b3d9ace297d3a016c202a42642"
+  integrity sha512-UvB7mRqQjivdZNxJNEA2yOQRB7L9N43nBnKc33K47+cH90/ujmnMwatTCwQLu83gLhrzAl8fsa6Lqig/KLghaA==
+  dependencies:
+    "@babel/runtime" "^7.22.5"
+    "@restart/hooks" "^0.4.9"
+    "@restart/ui" "^1.6.8"
+    "@types/react-transition-group" "^4.4.6"
+    classnames "^2.3.2"
+    dom-helpers "^5.2.1"
+    invariant "^2.2.4"
+    prop-types "^15.8.1"
+    prop-types-extra "^1.1.0"
+    react-transition-group "^4.4.5"
+    uncontrollable "^7.2.1"
+    warning "^4.0.3"
+
 react-dev-utils@^12.0.1:
   version "12.0.1"
   resolved "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz"
@@ -7847,7 +7959,7 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.3.2:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -7861,6 +7973,11 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
 react-refresh@^0.11.0:
   version "0.11.0"
@@ -7936,6 +8053,16 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-transition-group@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^18.2.0:
   version "18.2.0"
@@ -9012,7 +9139,7 @@ tslib@^1.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.4.0:
   version "2.6.2"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -9126,6 +9253,21 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+uncontrollable@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-7.2.1.tgz#1fa70ba0c57a14d5f78905d533cf63916dc75738"
+  integrity sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+    "@types/react" ">=16.9.11"
+    invariant "^2.2.4"
+    react-lifecycles-compat "^3.0.4"
+
+uncontrollable@^8.0.1:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-8.0.4.tgz#a0a8307f638795162fafd0550f4a1efa0f8c5eb6"
+  integrity sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==
 
 underscore@1.12.1:
   version "1.12.1"
@@ -9279,6 +9421,13 @@ walker@^1.0.7:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+warning@^4.0.0, warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
I've added a dropdown that changes the sort type and changes the url parameter sent to the API accordingly.

This change also adds an optional parameter to the `refetch` function generated by `useAxios`, which allows us to change the axios config on a refresh event. I've used this to switch the params around when the dropdown is pressed.

Sister PR: https://github.com/Seanlebon/reviveme-be/pull/26